### PR TITLE
feat: 팔로우, 언팔로우, 팔로우하는 사람들 최근 게시물 가져오기 기능

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       POSTGRES_PASSWORD: 1234
     ports:
       - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
     networks:
       - backend
 

--- a/src/main/java/com/runningmate/backend/GlobalExceptionHandler.java
+++ b/src/main/java/com/runningmate/backend/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.runningmate.backend;
 
 import com.runningmate.backend.exception.ErrorMessageResponseDTO;
+import com.runningmate.backend.exception.ExistsConflictException;
 import com.runningmate.backend.exception.FieldExistsException;
 import com.runningmate.backend.exception.ResourceNotFoundException;
 import org.springframework.http.HttpStatus;
@@ -20,6 +21,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(FieldExistsException.class)
     public ResponseEntity<Map<String, List<String>>> handleFieldExistsException(FieldExistsException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("exists", e.getExists()));
+    }
+
+    @ExceptionHandler(ExistsConflictException.class)
+    public ResponseEntity<ErrorMessageResponseDTO> handleAlreadyFollowingException(ExistsConflictException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(new ErrorMessageResponseDTO(e.getMessage()));
     }
 
     @ExceptionHandler(ResourceNotFoundException.class)

--- a/src/main/java/com/runningmate/backend/authentication/controller/AuthController.java
+++ b/src/main/java/com/runningmate/backend/authentication/controller/AuthController.java
@@ -1,12 +1,8 @@
 package com.runningmate.backend.authentication.controller;
 
 import com.runningmate.backend.authentication.service.AuthService;
-import com.runningmate.backend.member.Member;
-import com.runningmate.backend.member.MemberSignupRequest;
 import com.runningmate.backend.member.service.MemberService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -28,9 +24,4 @@ public class AuthController {
 
     private final MemberService memberService;
 
-    @PostMapping("/signup")
-    public ResponseEntity<Object> userSignup(@Valid @RequestBody MemberSignupRequest memberSignupRequest) {
-        Member newMember = memberService.signup(memberSignupRequest);
-        return ResponseEntity.ok().body(memberSignupRequest);
-    }
 }

--- a/src/main/java/com/runningmate/backend/authentication/controller/AuthController.java
+++ b/src/main/java/com/runningmate/backend/authentication/controller/AuthController.java
@@ -1,11 +1,13 @@
 package com.runningmate.backend.authentication.controller;
 
 import com.runningmate.backend.authentication.service.AuthService;
+import com.runningmate.backend.member.Member;
+import com.runningmate.backend.member.MemberSignupRequest;
+import com.runningmate.backend.member.service.MemberService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -22,5 +24,13 @@ public class AuthController {
         Map<String, Boolean> result = new HashMap<>();
         result.put("exists", exists);
         return result;
+    }
+
+    private final MemberService memberService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<Object> userSignup(@Valid @RequestBody MemberSignupRequest memberSignupRequest) {
+        Member newMember = memberService.signup(memberSignupRequest);
+        return ResponseEntity.ok().body(memberSignupRequest);
     }
 }

--- a/src/main/java/com/runningmate/backend/config/JsonUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/com/runningmate/backend/config/JsonUsernamePasswordAuthenticationFilter.java
@@ -33,6 +33,7 @@ public class JsonUsernamePasswordAuthenticationFilter extends AbstractAuthentica
         this.objectMapper = objectMapper;
     }
 
+    //TODO: Fix 500 error from occurring when client sends wrong data type
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException, ServletException {
         if(request.getContentType() == null || !request.getContentType().equals(CONTENT_TYPE)  ) {

--- a/src/main/java/com/runningmate/backend/config/JsonUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/com/runningmate/backend/config/JsonUsernamePasswordAuthenticationFilter.java
@@ -23,7 +23,7 @@ public class JsonUsernamePasswordAuthenticationFilter extends AbstractAuthentica
     private static final String CONTENT_TYPE = "application/json";
     private final ObjectMapper objectMapper; //to parse json
 
-    private static final String USERNAME_KEY="username";
+    private static final String EMAIL_KEY="email";
     private static final String PASSWORD_KEY="password";
     private static final AntPathRequestMatcher DEFAULT_LOGIN_PATH_REQUEST_MATCHER =
             new AntPathRequestMatcher(DEFAULT_LOGIN_REQUEST_URL, HTTP_METHOD);
@@ -42,12 +42,12 @@ public class JsonUsernamePasswordAuthenticationFilter extends AbstractAuthentica
 
         String messageBody = StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8);
 
-        Map<String, String> usernamePasswordMap = objectMapper.readValue(messageBody, Map.class);
+        Map<String, String> emailPasswordMap = objectMapper.readValue(messageBody, Map.class);
 
-        String username = usernamePasswordMap.get(USERNAME_KEY);
-        String password = usernamePasswordMap.get(PASSWORD_KEY);
+        String email = emailPasswordMap.get(EMAIL_KEY);
+        String password = emailPasswordMap.get(PASSWORD_KEY);
 
-        UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(username, password);//principal 과 credentials 전달
+        UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(email, password);//principal 과 credentials 전달
 
         return this.getAuthenticationManager().authenticate(authRequest);
     }

--- a/src/main/java/com/runningmate/backend/exception/ExistsConflictException.java
+++ b/src/main/java/com/runningmate/backend/exception/ExistsConflictException.java
@@ -1,0 +1,7 @@
+package com.runningmate.backend.exception;
+
+public class ExistsConflictException extends RuntimeException {
+    public ExistsConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/runningmate/backend/member/Follow.java
+++ b/src/main/java/com/runningmate/backend/member/Follow.java
@@ -1,0 +1,26 @@
+package com.runningmate.backend.member;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(name = "follow")
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Follow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "follow_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "follower_member_id")
+    private Member follower;
+
+    @ManyToOne
+    @JoinColumn(name = "following_member_id")
+    private Member following;
+}

--- a/src/main/java/com/runningmate/backend/member/Member.java
+++ b/src/main/java/com/runningmate/backend/member/Member.java
@@ -47,6 +47,7 @@ public class Member {
     @Column
     private LocalDateTime modifiedAt;
 
+
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();

--- a/src/main/java/com/runningmate/backend/member/Member.java
+++ b/src/main/java/com/runningmate/backend/member/Member.java
@@ -6,6 +6,8 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Table(name = "member")
 @Getter
@@ -47,6 +49,11 @@ public class Member {
     @Column
     private LocalDateTime modifiedAt;
 
+    @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Follow> followers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "following", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Follow> followings = new ArrayList<>();
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/com/runningmate/backend/member/controller/MemberController.java
+++ b/src/main/java/com/runningmate/backend/member/controller/MemberController.java
@@ -11,20 +11,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @RestController
+@RequestMapping("/member")
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;
 
-    @PostMapping("/signup")
-    public ResponseEntity<Object> userSignup(@Valid @RequestBody MemberSignupRequest memberSignupRequest) {
-        Member newMember = memberService.signup(memberSignupRequest);
-        return ResponseEntity.ok().body(memberSignupRequest);
-    }
-
+    
 }

--- a/src/main/java/com/runningmate/backend/member/controller/MemberController.java
+++ b/src/main/java/com/runningmate/backend/member/controller/MemberController.java
@@ -1,20 +1,12 @@
 package com.runningmate.backend.member.controller;
 
 import com.runningmate.backend.member.Member;
-import com.runningmate.backend.member.MemberSignupRequest;
 import com.runningmate.backend.member.service.MemberService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/member")

--- a/src/main/java/com/runningmate/backend/member/controller/MemberController.java
+++ b/src/main/java/com/runningmate/backend/member/controller/MemberController.java
@@ -8,11 +8,10 @@ import lombok.RequiredArgsConstructor;
 import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,5 +22,21 @@ import java.util.Map;
 public class MemberController {
     private final MemberService memberService;
 
+    @ResponseStatus(value = HttpStatus.OK)
+    @PostMapping("/{memberId}/follow")
+    public void followUser(@PathVariable(name = "memberId") Long memberId, @AuthenticationPrincipal UserDetails userDetails) {
+        String username = userDetails.getUsername();
+        Member follower = memberService.getMemberByUsername(username);
+        Member following = memberService.getMemberById(memberId);
+        memberService.followUser(follower, following);
+    }
 
+    @ResponseStatus(value = HttpStatus.OK)
+    @PostMapping("/{memberId}/unfollow")
+    public void unfollowUser(@PathVariable(name = "memberId") Long memberId, @AuthenticationPrincipal UserDetails userDetails) {
+        String username = userDetails.getUsername();
+        Member follower = memberService.getMemberByUsername(username);
+        Member following = memberService.getMemberById(memberId);
+        memberService.unfollowUser(follower, following);
+    }
 }

--- a/src/main/java/com/runningmate/backend/member/controller/MemberController.java
+++ b/src/main/java/com/runningmate/backend/member/controller/MemberController.java
@@ -23,5 +23,5 @@ import java.util.Map;
 public class MemberController {
     private final MemberService memberService;
 
-    
+
 }

--- a/src/main/java/com/runningmate/backend/member/controller/SignupController.java
+++ b/src/main/java/com/runningmate/backend/member/controller/SignupController.java
@@ -1,6 +1,6 @@
 package com.runningmate.backend.member.controller;
 
-import com.runningmate.backend.member.Member;
+import com.runningmate.backend.member.dto.MemberDto;
 import com.runningmate.backend.member.dto.MemberSignupRequest;
 import com.runningmate.backend.member.service.MemberService;
 import jakarta.validation.Valid;
@@ -17,7 +17,7 @@ public class SignupController {
 
     @PostMapping("/signup")
     public ResponseEntity<Object> userSignup(@Valid @RequestBody MemberSignupRequest memberSignupRequest) {
-        Member newMember = memberService.signup(memberSignupRequest);
-        return ResponseEntity.ok().body(memberSignupRequest);
+        MemberDto newMember = memberService.signup(memberSignupRequest);
+        return ResponseEntity.ok().body(newMember);
     }
 }

--- a/src/main/java/com/runningmate/backend/member/controller/SignupController.java
+++ b/src/main/java/com/runningmate/backend/member/controller/SignupController.java
@@ -1,0 +1,23 @@
+package com.runningmate.backend.member.controller;
+
+import com.runningmate.backend.member.Member;
+import com.runningmate.backend.member.MemberSignupRequest;
+import com.runningmate.backend.member.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SignupController {
+    private final MemberService memberService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<Object> userSignup(@Valid @RequestBody MemberSignupRequest memberSignupRequest) {
+        Member newMember = memberService.signup(memberSignupRequest);
+        return ResponseEntity.ok().body(memberSignupRequest);
+    }
+}

--- a/src/main/java/com/runningmate/backend/member/controller/SignupController.java
+++ b/src/main/java/com/runningmate/backend/member/controller/SignupController.java
@@ -1,7 +1,7 @@
 package com.runningmate.backend.member.controller;
 
 import com.runningmate.backend.member.Member;
-import com.runningmate.backend.member.MemberSignupRequest;
+import com.runningmate.backend.member.dto.MemberSignupRequest;
 import com.runningmate.backend.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/runningmate/backend/member/dto/MemberDto.java
+++ b/src/main/java/com/runningmate/backend/member/dto/MemberDto.java
@@ -1,0 +1,24 @@
+package com.runningmate.backend.member.dto;
+
+import com.runningmate.backend.member.Member;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberDto {
+    private Long id;
+    private String username;
+    private String email;
+    private String name;
+
+    public static MemberDto fromEntity(Member member) {
+        return MemberDto.builder()
+                .id(member.getId())
+                .username(member.getUsername())
+                .email(member.getEmail())
+                .name(member.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/runningmate/backend/member/dto/MemberSignupRequest.java
+++ b/src/main/java/com/runningmate/backend/member/dto/MemberSignupRequest.java
@@ -1,4 +1,4 @@
-package com.runningmate.backend.member;
+package com.runningmate.backend.member.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/runningmate/backend/member/dto/PostResponseDto.java
+++ b/src/main/java/com/runningmate/backend/member/dto/PostResponseDto.java
@@ -1,0 +1,32 @@
+package com.runningmate.backend.member.dto;
+
+import com.runningmate.backend.posts.Post;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostResponseDto {
+    private Long id;
+    private String title;
+    private String content;
+    private MemberDto member;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static PostResponseDto fromEntity(Post post) {
+        MemberDto memberDto = MemberDto.fromEntity(post.getMember());
+
+        return PostResponseDto.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .createdAt(post.getCreatedAt())
+                .modifiedAt(post.getModifiedAt())
+                .member(memberDto)
+                .build();
+    }
+}

--- a/src/main/java/com/runningmate/backend/member/repository/FollowRepository.java
+++ b/src/main/java/com/runningmate/backend/member/repository/FollowRepository.java
@@ -5,8 +5,11 @@ import com.runningmate.backend.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     List<Follow> findByFollower(Member follower);
     List<Follow> findByFollowing(Member following);
+    boolean existsByFollowerAndFollowing(Member follower, Member following);
+    Optional<Follow> findByFollowerAndFollowing(Member follower, Member following);
 }

--- a/src/main/java/com/runningmate/backend/member/repository/FollowRepository.java
+++ b/src/main/java/com/runningmate/backend/member/repository/FollowRepository.java
@@ -1,0 +1,12 @@
+package com.runningmate.backend.member.repository;
+
+import com.runningmate.backend.member.Follow;
+import com.runningmate.backend.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    List<Follow> findByFollower(Member follower);
+    List<Follow> findByFollowing(Member following);
+}

--- a/src/main/java/com/runningmate/backend/member/service/LoginService.java
+++ b/src/main/java/com/runningmate/backend/member/service/LoginService.java
@@ -17,7 +17,7 @@ public class LoginService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         Member member = memberRepository.findByEmail(email).orElseThrow(() -> new UsernameNotFoundException("User not found"));
-        UserDetails user = User.builder().username(member.getEmail())
+        UserDetails user = User.builder().username(member.getUsername())
                 .password(member.getPassword())
                 .roles(member.getRole().name())
                 .build();

--- a/src/main/java/com/runningmate/backend/member/service/LoginService.java
+++ b/src/main/java/com/runningmate/backend/member/service/LoginService.java
@@ -15,9 +15,9 @@ public class LoginService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member member = memberRepository.findByUsername(username).orElseThrow(() -> new UsernameNotFoundException("User not found"));
-        UserDetails user = User.builder().username(member.getUsername())
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        UserDetails user = User.builder().username(member.getEmail())
                 .password(member.getPassword())
                 .roles(member.getRole().name())
                 .build();

--- a/src/main/java/com/runningmate/backend/member/service/MemberService.java
+++ b/src/main/java/com/runningmate/backend/member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.runningmate.backend.exception.ExistsConflictException;
 import com.runningmate.backend.exception.ResourceNotFoundException;
 import com.runningmate.backend.member.Follow;
 import com.runningmate.backend.member.Member;
+import com.runningmate.backend.member.dto.MemberDto;
 import com.runningmate.backend.member.dto.MemberSignupRequest;
 import com.runningmate.backend.member.Role;
 import com.runningmate.backend.exception.FieldExistsException;
@@ -24,7 +25,7 @@ public class MemberService {
     private final FollowRepository followRepository;
 
 
-    public Member signup(MemberSignupRequest memberSignupRequest) throws FieldExistsException {
+    public MemberDto signup(MemberSignupRequest memberSignupRequest) throws FieldExistsException {
         List<String> exists = checkExistingFields(memberSignupRequest);
 
         if (!exists.isEmpty()) {
@@ -33,8 +34,8 @@ public class MemberService {
 
         Member member = createMember(memberSignupRequest);
 
-        memberRepository.save(member);
-        return member;
+        Member savedMember = memberRepository.save(member);
+        return MemberDto.fromEntity(savedMember);
     }
 
     public Member getMemberByUsername(String username) {

--- a/src/main/java/com/runningmate/backend/member/service/MemberService.java
+++ b/src/main/java/com/runningmate/backend/member/service/MemberService.java
@@ -1,10 +1,13 @@
 package com.runningmate.backend.member.service;
 
+import com.runningmate.backend.exception.ExistsConflictException;
 import com.runningmate.backend.exception.ResourceNotFoundException;
+import com.runningmate.backend.member.Follow;
 import com.runningmate.backend.member.Member;
 import com.runningmate.backend.member.MemberSignupRequest;
 import com.runningmate.backend.member.Role;
 import com.runningmate.backend.exception.FieldExistsException;
+import com.runningmate.backend.member.repository.FollowRepository;
 import com.runningmate.backend.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -12,12 +15,14 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final FollowRepository followRepository;
 
 
     public Member signup(MemberSignupRequest memberSignupRequest) throws FieldExistsException {
@@ -36,6 +41,31 @@ public class MemberService {
     public Member getMemberByUsername(String username) {
         return memberRepository.findByUsername(username)
                 .orElseThrow(() -> new ResourceNotFoundException("Member with User Name: " + username + " not found."));
+    }
+
+    public Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(() -> new ResourceNotFoundException("Member with member_id: " + memberId + " not found."));
+    }
+
+    public void followUser(Member follower, Member following) {
+        if (followRepository.existsByFollowerAndFollowing(follower, following)) {
+            throw new ExistsConflictException(follower.getUsername() + " is already following " + following.getUsername());
+        }
+        Follow newFollow = createFollow(follower, following);
+        followRepository.save(newFollow);
+    }
+
+    public void unfollowUser(Member follower, Member following) {
+        Follow follow = followRepository.findByFollowerAndFollowing(follower, following)
+                .orElseThrow(() -> new ResourceNotFoundException(follower.getUsername() + " is not following " + following.getUsername()));
+        followRepository.delete(follow);
+    }
+
+    private Follow createFollow(Member follower, Member following) {
+        return Follow.builder()
+                .follower(follower)
+                .following(following)
+                .build();
     }
 
     private List<String> checkExistingFields(MemberSignupRequest request) {

--- a/src/main/java/com/runningmate/backend/member/service/MemberService.java
+++ b/src/main/java/com/runningmate/backend/member/service/MemberService.java
@@ -4,7 +4,7 @@ import com.runningmate.backend.exception.ExistsConflictException;
 import com.runningmate.backend.exception.ResourceNotFoundException;
 import com.runningmate.backend.member.Follow;
 import com.runningmate.backend.member.Member;
-import com.runningmate.backend.member.MemberSignupRequest;
+import com.runningmate.backend.member.dto.MemberSignupRequest;
 import com.runningmate.backend.member.Role;
 import com.runningmate.backend.exception.FieldExistsException;
 import com.runningmate.backend.member.repository.FollowRepository;
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/runningmate/backend/posts/controller/PostController.java
+++ b/src/main/java/com/runningmate/backend/posts/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.runningmate.backend.posts.controller;
 
 import com.runningmate.backend.member.Member;
+import com.runningmate.backend.member.dto.PostResponseDto;
 import com.runningmate.backend.member.service.MemberService;
 import com.runningmate.backend.posts.Post;
 import com.runningmate.backend.posts.dto.CreatePostRequest;
@@ -25,14 +26,14 @@ public class PostController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("")
-    public Post createNewPost(@Valid @RequestBody CreatePostRequest createPostRequest, Authentication authentication) {
+    public PostResponseDto createNewPost(@Valid @RequestBody CreatePostRequest createPostRequest, Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         return postService.createPost(createPostRequest, userDetails.getUsername());
     }
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("")
-    public List<Post> getRecentPosts(@AuthenticationPrincipal UserDetails userDetails) {
+    public List<PostResponseDto> getRecentPosts(@AuthenticationPrincipal UserDetails userDetails) {
         String username = userDetails.getUsername();
         Member user = memberService.getMemberByUsername(username);
         return postService.getRecentPostsOfFollowedMembers(user);

--- a/src/main/java/com/runningmate/backend/posts/controller/PostController.java
+++ b/src/main/java/com/runningmate/backend/posts/controller/PostController.java
@@ -1,5 +1,7 @@
 package com.runningmate.backend.posts.controller;
 
+import com.runningmate.backend.member.Member;
+import com.runningmate.backend.member.service.MemberService;
 import com.runningmate.backend.posts.Post;
 import com.runningmate.backend.posts.dto.CreatePostRequest;
 import com.runningmate.backend.posts.service.PostService;
@@ -8,20 +10,32 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/posts")
 public class PostController {
     private final PostService postService;
+    private final MemberService memberService;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("")
     public Post createNewPost(@Valid @RequestBody CreatePostRequest createPostRequest, Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         return postService.createPost(createPostRequest, userDetails.getUsername());
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("")
+    public List<Post> getRecentPosts(@AuthenticationPrincipal UserDetails userDetails) {
+        String username = userDetails.getUsername();
+        Member user = memberService.getMemberByUsername(username);
+        return postService.getRecentPostsOfFollowedMembers(user);
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/runningmate/backend/posts/repository/PostRepository.java
+++ b/src/main/java/com/runningmate/backend/posts/repository/PostRepository.java
@@ -2,6 +2,7 @@ package com.runningmate.backend.posts.repository;
 
 import com.runningmate.backend.member.Member;
 import com.runningmate.backend.posts.Post;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,5 +14,5 @@ import java.util.Optional;
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByMember(Member member);
     List<Post> findAllByCreatedAt(LocalDate date);
-
+    List<Post> findByMemberInOrderByCreatedAtDesc(List<Member> members, Pageable pageable);
 }

--- a/src/main/java/com/runningmate/backend/posts/service/PostService.java
+++ b/src/main/java/com/runningmate/backend/posts/service/PostService.java
@@ -64,9 +64,9 @@ public class PostService {
     }
 
     //TODO: Might have to let the client know if a post with Id does not exist.
-//    public void deletePost(Long id) {
-//        postRepository.deleteById(id);
-//    }
+    //    public void deletePost(Long id) {
+    //        postRepository.deleteById(id);
+    //    }
 
     public List<Post> getPostsByMember(Member member) {
         return postRepository.findAllByMember(member);

--- a/src/main/java/com/runningmate/backend/posts/service/PostService.java
+++ b/src/main/java/com/runningmate/backend/posts/service/PostService.java
@@ -1,18 +1,23 @@
 package com.runningmate.backend.posts.service;
 
 import com.runningmate.backend.exception.ResourceNotFoundException;
+import com.runningmate.backend.member.Follow;
 import com.runningmate.backend.member.Member;
+import com.runningmate.backend.member.repository.FollowRepository;
 import com.runningmate.backend.member.service.MemberService;
 import com.runningmate.backend.posts.Post;
 import com.runningmate.backend.posts.dto.CreatePostRequest;
 import com.runningmate.backend.posts.repository.PostLikeRepository;
 import com.runningmate.backend.posts.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +26,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final PostLikeService postLikeService;
     private final MemberService memberService;
+    private final FollowRepository followRepository;
 
 
     public Post createPost(CreatePostRequest postRequest, String username) {
@@ -36,6 +42,16 @@ public class PostService {
                     return postRepository.save(post);
                 })
                 .orElseThrow(() -> new ResourceNotFoundException("Post not found with id " + id));
+    }
+
+    public List<Post> getRecentPostsOfFollowedMembers(Member user) {
+        List<Follow> follows = followRepository.findByFollower(user);
+        List<Member> followedMembers = follows.stream()
+                .map(Follow::getFollowing)
+                .collect(Collectors.toList());
+
+        Pageable pageable = PageRequest.of(0, 30);
+        return postRepository.findByMemberInOrderByCreatedAtDesc(followedMembers, pageable);
     }
 
     public Optional<Post> getPostById(Long id) {


### PR DESCRIPTION
# Describe your changes
- make an api to follow another user and also to unfollow 
`/member/{memberId}/follow` `/member/{memberId}/unfollow`
<img width="921" alt="image" src="https://github.com/SSOCK/Back/assets/33882299/c185a6ac-543b-4989-8992-f876d8b8fa55">

- Get request to `/posts` gets recent posts of the user's following list
<img width="947" alt="image" src="https://github.com/SSOCK/Back/assets/33882299/af3bab67-1f9e-4a46-9480-2757da8d9f75">

- Changed login api so that it takes 
`{"email": String, "password": String}` not  `{"username": String, "password": String}` 


# What did you learn?
- 전에 팔로우 하는 사람들의 포스트를 리턴해줄때 엔티티를 리턴해주었는데 JPA에서 양방향 참조를 이용하여서 순환참조가 되어서 계속 무한 루프를 돈다. 이것을 방지 하기 위해서 DTO를 생성해주고 DTO 안에 fromEntity 메서드를 추가해주어 entity에서 dto로 변환할수 있게 해주었다.

<img width="610" alt="image" src="https://github.com/SSOCK/Back/assets/33882299/291a2bfa-5633-4fcb-bd65-0b81c6568110">

