### PR TITLE
feat: created a new api endpoint to reissue access token using refresh token

### DIFF
--- a/src/main/java/com/runningmate/backend/GlobalExceptionHandler.java
+++ b/src/main/java/com/runningmate/backend/GlobalExceptionHandler.java
@@ -35,6 +35,11 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorMessageResponseDTO(e.getMessage()));
     }
 
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<ErrorMessageResponseDTO> handleInvalidJWTTokenException(InvalidTokenException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorMessageResponseDTO(e.getMessage()));
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException e) {
         Map<String, String> errors = new HashMap<>();

--- a/src/main/java/com/runningmate/backend/authentication/controller/AuthController.java
+++ b/src/main/java/com/runningmate/backend/authentication/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.runningmate.backend.jwt.service.JwtService;
 import com.runningmate.backend.member.Member;
 import com.runningmate.backend.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -31,6 +32,7 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
+    @ResponseStatus(value = HttpStatus.CREATED)
     public AccessTokenReissueDto reissueAccessToken(@CookieValue(value = "refresh-token", defaultValue = "") String refreshToken) throws InvalidTokenException{
         if (!refreshToken.isEmpty() && jwtService.isTokenValid(refreshToken)) {
             Optional<String> usernameOpt = jwtService.extractUsername(refreshToken);

--- a/src/main/java/com/runningmate/backend/authentication/controller/AuthController.java
+++ b/src/main/java/com/runningmate/backend/authentication/controller/AuthController.java
@@ -1,12 +1,17 @@
 package com.runningmate.backend.authentication.controller;
 
+import com.runningmate.backend.authentication.dto.AccessTokenReissueDto;
 import com.runningmate.backend.authentication.service.AuthService;
+import com.runningmate.backend.exception.InvalidTokenException;
+import com.runningmate.backend.jwt.service.JwtService;
+import com.runningmate.backend.member.Member;
 import com.runningmate.backend.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @RestController
 @CrossOrigin(origins = "*", allowedHeaders = "*", methods = {RequestMethod.GET})
@@ -14,6 +19,8 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
+    private final JwtService jwtService;
+    private final MemberService memberService;
 
     @GetMapping("/valid/user/{username}")
     public Map<String, Boolean> usernameExists(@PathVariable("username") String username) {
@@ -23,6 +30,21 @@ public class AuthController {
         return result;
     }
 
-    private final MemberService memberService;
+    @PostMapping("/refresh")
+    public AccessTokenReissueDto reissueAccessToken(@CookieValue(value = "refresh-token", defaultValue = "") String refreshToken) throws InvalidTokenException{
+        if (!refreshToken.isEmpty() && jwtService.isTokenValid(refreshToken)) {
+            Optional<String> usernameOpt = jwtService.extractUsername(refreshToken);
+            if (usernameOpt.isPresent()) {
+                String username = usernameOpt.get();
+                Member member = memberService.getMemberByUsername(username);
+                if (member.getRefreshtoken().equals(refreshToken)) {
+                    String newAccessToken = jwtService.createAccessToken(username);
+                    AccessTokenReissueDto accessTokenReissueDto = new AccessTokenReissueDto(newAccessToken);
+                    return accessTokenReissueDto;
+                }
+            }
+        }
 
+        throw new InvalidTokenException();
+    }
 }

--- a/src/main/java/com/runningmate/backend/authentication/dto/AccessTokenReissueDto.java
+++ b/src/main/java/com/runningmate/backend/authentication/dto/AccessTokenReissueDto.java
@@ -1,0 +1,12 @@
+package com.runningmate.backend.authentication.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class AccessTokenReissueDto {
+    @JsonProperty("access-token")
+    private String accessToken;
+}

--- a/src/main/java/com/runningmate/backend/exception/ErrorMessageResponseDTO.java
+++ b/src/main/java/com/runningmate/backend/exception/ErrorMessageResponseDTO.java
@@ -1,8 +1,11 @@
 package com.runningmate.backend.exception;
 
 import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
 
 @AllArgsConstructor
+@Getter
 public class ErrorMessageResponseDTO {
     private String error;
 }

--- a/src/main/java/com/runningmate/backend/exception/InvalidTokenException.java
+++ b/src/main/java/com/runningmate/backend/exception/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.runningmate.backend.exception;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException() {
+        super("Provided token is not valid");
+    }
+}


### PR DESCRIPTION
# Describe your changes
<img width="715" alt="image" src="https://github.com/SSOCK/Back/assets/33882299/db6904b8-3ec4-49b5-b844-9a79320b0a22">

- using the standards from OAuth2.0 when client sends access token using Authorization header and receives 401, the client sends a post request to /auth/refresh with "refresh-token" cookie with refresh token string to receive a new access token.
- then the client uses the new access token to make the request that failed. 
