### PR TITLE
feat: get likes and comments when getting posts 

### DIFF
--- a/src/main/java/com/runningmate/backend/member/controller/MemberController.java
+++ b/src/main/java/com/runningmate/backend/member/controller/MemberController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
     private final MemberService memberService;
 
-    @ResponseStatus(value = HttpStatus.OK)
+    @ResponseStatus(value = HttpStatus.CREATED)
     @PostMapping("/{memberId}/follow")
     public void followUser(@PathVariable(name = "memberId") Long memberId, @AuthenticationPrincipal UserDetails userDetails) {
         String username = userDetails.getUsername();

--- a/src/main/java/com/runningmate/backend/member/controller/MemberController.java
+++ b/src/main/java/com/runningmate/backend/member/controller/MemberController.java
@@ -24,7 +24,7 @@ public class MemberController {
     }
 
     @ResponseStatus(value = HttpStatus.OK)
-    @PostMapping("/{memberId}/unfollow")
+    @DeleteMapping("/{memberId}/unfollow")
     public void unfollowUser(@PathVariable(name = "memberId") Long memberId, @AuthenticationPrincipal UserDetails userDetails) {
         String username = userDetails.getUsername();
         Member follower = memberService.getMemberByUsername(username);

--- a/src/main/java/com/runningmate/backend/posts/Comment.java
+++ b/src/main/java/com/runningmate/backend/posts/Comment.java
@@ -7,38 +7,30 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
-@Table(name = "post")
+@Table(name = "comment")
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Post {
+public class Comment {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "post_id")
+    @Column(name = "comment_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @Column(nullable = false, length = 100)
-    private String title;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
 
     @Column(columnDefinition = "TEXT")
     private String content;
-
-    @Column(length = 255)
-    private String imageUrl; // Add this field
-
-    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
-    @OrderBy("createdAt asc") //Order by time, 시간 순으로 정렬
-    private List<Comment> comments = new ArrayList<>();
 
     @CreatedDate
     @Column(updatable = false)
@@ -56,10 +48,5 @@ public class Post {
     @PreUpdate
     protected void onUpdate() {
         this.modifiedAt = LocalDateTime.now();
-    }
-
-    public void updatePost(String title, String content) {
-        this.title = title;
-        this.content = content;
     }
 }

--- a/src/main/java/com/runningmate/backend/posts/controller/CommentController.java
+++ b/src/main/java/com/runningmate/backend/posts/controller/CommentController.java
@@ -1,0 +1,11 @@
+package com.runningmate.backend.posts.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/comments")
+public class CommentController {
+}

--- a/src/main/java/com/runningmate/backend/posts/controller/PostController.java
+++ b/src/main/java/com/runningmate/backend/posts/controller/PostController.java
@@ -1,9 +1,12 @@
 package com.runningmate.backend.posts.controller;
 
 import com.runningmate.backend.member.Member;
+import com.runningmate.backend.posts.dto.CommentRequestDto;
+import com.runningmate.backend.posts.dto.CommentResponseDto;
 import com.runningmate.backend.posts.dto.PostResponseDto;
 import com.runningmate.backend.member.service.MemberService;
 import com.runningmate.backend.posts.dto.CreatePostRequest;
+import com.runningmate.backend.posts.service.CommentService;
 import com.runningmate.backend.posts.service.GcsFileStorageService;
 import com.runningmate.backend.posts.service.PostService;
 import jakarta.validation.Valid;
@@ -24,6 +27,7 @@ import java.util.List;
 public class PostController {
     private final PostService postService;
     private final MemberService memberService;
+    private final CommentService commentService;
     private final GcsFileStorageService gcsFileStorageService;
 
     @ResponseStatus(HttpStatus.CREATED)
@@ -47,6 +51,13 @@ public class PostController {
     public void toggleLike(@PathVariable(name = "postId") Long postId, Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         postService.toggleLike(postId, userDetails.getUsername());
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/{postId}/comments")
+    public CommentResponseDto commentOnPost(@PathVariable(name = "postId") Long postId, @Valid @RequestBody CommentRequestDto commentRequestDto, Authentication authentication) {
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        return commentService.saveComment(userDetails.getUsername(), commentRequestDto, postId);
     }
 
 }

--- a/src/main/java/com/runningmate/backend/posts/controller/PostController.java
+++ b/src/main/java/com/runningmate/backend/posts/controller/PostController.java
@@ -53,7 +53,7 @@ public class PostController {
         postService.toggleLike(postId, userDetails.getUsername());
     }
 
-    @ResponseStatus(HttpStatus.OK)
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{postId}/comments")
     public CommentResponseDto commentOnPost(@PathVariable(name = "postId") Long postId, @Valid @RequestBody CommentRequestDto commentRequestDto, Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();

--- a/src/main/java/com/runningmate/backend/posts/dto/CommentRequestDto.java
+++ b/src/main/java/com/runningmate/backend/posts/dto/CommentRequestDto.java
@@ -1,0 +1,31 @@
+package com.runningmate.backend.posts.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.runningmate.backend.member.Member;
+import com.runningmate.backend.posts.Comment;
+import com.runningmate.backend.posts.Post;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentRequestDto {
+    @NotBlank(message = "Content has to include non-whitespace characters")
+    @Size(max = 2000)
+    private String content;
+
+    public Comment toEntity(Member member, Post post) {
+        Comment comment = Comment.builder()
+                .member(member)
+                .post(post)
+                .content(content)
+                .build();
+        return comment;
+    }
+}

--- a/src/main/java/com/runningmate/backend/posts/dto/CommentResponseDto.java
+++ b/src/main/java/com/runningmate/backend/posts/dto/CommentResponseDto.java
@@ -1,0 +1,25 @@
+package com.runningmate.backend.posts.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.runningmate.backend.posts.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CommentResponseDto {
+    private Long id;
+    private String content;
+    private String username;
+    private LocalDateTime createdAt;
+    private Long postId;
+
+    public CommentResponseDto(Comment comment) {
+        this.id = comment.getId();
+        this.content = comment.getContent();
+        this.username = comment.getMember().getUsername();
+        this.createdAt = comment.getCreatedAt();
+        this.postId = comment.getPost().getId();
+    }
+}

--- a/src/main/java/com/runningmate/backend/posts/dto/PostResponseDto.java
+++ b/src/main/java/com/runningmate/backend/posts/dto/PostResponseDto.java
@@ -16,16 +16,18 @@ public class PostResponseDto {
     private String content;
     private MemberDto member;
     private String imageUrl;
+    private Integer likes;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
-    public static PostResponseDto fromEntity(Post post) {
+    public static PostResponseDto fromEntity(Post post, Integer likes) {
         MemberDto memberDto = MemberDto.fromEntity(post.getMember());
 
         return PostResponseDto.builder()
                 .id(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
+                .likes(likes)
                 .createdAt(post.getCreatedAt())
                 .modifiedAt(post.getModifiedAt())
                 .imageUrl(post.getImageUrl())

--- a/src/main/java/com/runningmate/backend/posts/dto/PostResponseDto.java
+++ b/src/main/java/com/runningmate/backend/posts/dto/PostResponseDto.java
@@ -16,11 +16,11 @@ public class PostResponseDto {
     private String content;
     private MemberDto member;
     private String imageUrl;
-    private Integer likes;
+    private long likes;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
-    public static PostResponseDto fromEntity(Post post, Integer likes) {
+    public static PostResponseDto fromEntity(Post post, long likes) {
         MemberDto memberDto = MemberDto.fromEntity(post.getMember());
 
         return PostResponseDto.builder()

--- a/src/main/java/com/runningmate/backend/posts/dto/PostResponseDto.java
+++ b/src/main/java/com/runningmate/backend/posts/dto/PostResponseDto.java
@@ -5,6 +5,9 @@ import com.runningmate.backend.posts.Post;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -17,6 +20,7 @@ public class PostResponseDto {
     private MemberDto member;
     private String imageUrl;
     private long likes;
+    private List<CommentResponseDto> comments;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
@@ -28,6 +32,7 @@ public class PostResponseDto {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .likes(likes)
+                .comments(post.getComments().stream().map(CommentResponseDto::new).collect(Collectors.toList()))
                 .createdAt(post.getCreatedAt())
                 .modifiedAt(post.getModifiedAt())
                 .imageUrl(post.getImageUrl())

--- a/src/main/java/com/runningmate/backend/posts/repository/CommentRepository.java
+++ b/src/main/java/com/runningmate/backend/posts/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.runningmate.backend.posts.repository;
+
+import com.runningmate.backend.posts.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/com/runningmate/backend/posts/service/CommentService.java
+++ b/src/main/java/com/runningmate/backend/posts/service/CommentService.java
@@ -1,0 +1,30 @@
+package com.runningmate.backend.posts.service;
+
+import com.runningmate.backend.member.Member;
+import com.runningmate.backend.member.service.MemberService;
+import com.runningmate.backend.posts.Comment;
+import com.runningmate.backend.posts.Post;
+import com.runningmate.backend.posts.dto.CommentRequestDto;
+import com.runningmate.backend.posts.dto.CommentResponseDto;
+import com.runningmate.backend.posts.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final MemberService memberService;
+    private final PostService postService;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public CommentResponseDto saveComment(String username, CommentRequestDto dto, Long postId) {
+        Member member = memberService.getMemberByUsername(username);
+        Post post = postService.getPostById(postId);
+
+        Comment comment = dto.toEntity(member, post);
+        commentRepository.save(comment);
+        return new CommentResponseDto(comment);
+    }
+}

--- a/src/main/java/com/runningmate/backend/posts/service/PostLikeService.java
+++ b/src/main/java/com/runningmate/backend/posts/service/PostLikeService.java
@@ -23,7 +23,7 @@ public class PostLikeService {
         return postLikeRepository.existsByPostIdAndMemberId(postId, memberId);
     }
 
-    public int getLikeCountByPostId(Long postId) {
+    public long getLikeCountByPostId(Long postId) {
         return postLikeRepository.countByPostId(postId);
     }
 

--- a/src/main/java/com/runningmate/backend/posts/service/PostLikeService.java
+++ b/src/main/java/com/runningmate/backend/posts/service/PostLikeService.java
@@ -23,7 +23,7 @@ public class PostLikeService {
         return postLikeRepository.existsByPostIdAndMemberId(postId, memberId);
     }
 
-    public long getLikeCountByPostId(Long postId) {
+    public int getLikeCountByPostId(Long postId) {
         return postLikeRepository.countByPostId(postId);
     }
 

--- a/src/main/java/com/runningmate/backend/posts/service/PostService.java
+++ b/src/main/java/com/runningmate/backend/posts/service/PostService.java
@@ -33,7 +33,7 @@ public class PostService {
         Member member = memberService.getMemberByUsername(username);
         Post post = postRequest.toEntity(member, imageUrl);
         Post savedPost = postRepository.save(post);
-        return PostResponseDto.fromEntity(savedPost);
+        return PostResponseDto.fromEntity(savedPost, 0);
     }
 
     public Post updatePost(Long id, Post updatePostDTO) {//TODO: change to PostDTO
@@ -54,7 +54,7 @@ public class PostService {
         Pageable pageable = PageRequest.of(0, 30);
         List<Post> posts = postRepository.findByMemberInOrderByCreatedAtDesc(followedMembers, pageable);
 
-        return posts.stream().map(PostResponseDto::fromEntity).collect(Collectors.toList());
+        return posts.stream().map((Post post) -> PostResponseDto.fromEntity(post, postLikeService.getLikeCountByPostId(post.getId()))).collect(Collectors.toList());
     }
 
     public Optional<Post> getPostById(Long id) {

--- a/src/main/java/com/runningmate/backend/posts/service/PostService.java
+++ b/src/main/java/com/runningmate/backend/posts/service/PostService.java
@@ -37,12 +37,9 @@ public class PostService {
     }
 
     public Post updatePost(Long id, Post updatePostDTO) {//TODO: change to PostDTO
-        return this.getPostById(id)
-                .map(post -> {
-                    post.updatePost(updatePostDTO.getTitle(), updatePostDTO.getContent());
-                    return postRepository.save(post);
-                })
-                .orElseThrow(() -> new ResourceNotFoundException("Post not found with id " + id));
+        Post post = this.getPostById(id);
+        post.updatePost(updatePostDTO.getTitle(), updatePostDTO.getContent());
+        return postRepository.save(post);
     }
 
     public List<PostResponseDto> getRecentPostsOfFollowedMembers(Member user) {
@@ -57,8 +54,8 @@ public class PostService {
         return posts.stream().map((Post post) -> PostResponseDto.fromEntity(post, postLikeService.getLikeCountByPostId(post.getId()))).collect(Collectors.toList());
     }
 
-    public Optional<Post> getPostById(Long id) {
-        return postRepository.findById(id);
+    public Post getPostById(Long id) {
+        return postRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("Post not found with id " + id));
     }
 
     public boolean toggleLike(Long postId, String username) {


### PR DESCRIPTION
# Describe your changes
- Changed such that when getting posts from server, client receives comments on that post and the number of likes on that post

`GET http://serveraddress/posts`

```json
[
    {
        "id": 2,
        "title": "Cancer",
        "content": "What is this?",
        "member": {
            "id": 1,
            "username": "jinsoo2005",
            "email": "jin2005@gmail.com",
            "name": "jin"
        },
        "imageUrl": null,
        "likes": 0,
        "comments": [
            {
                "id": 1,
                "content": "blasfemy",
                "username": "jinsoo2006",
                "createdAt": "2024-06-05T00:57:09.528969",
                "postId": 2
            },
            {
                "id": 2,
                "content": "alohomora",
                "username": "jinsoo2006",
                "createdAt": "2024-06-05T01:05:23.972853",
                "postId": 2
            }
        ],
        "createdAt": "2024-05-20T00:07:12.993294",
        "modifiedAt": null
    },
    {
        "id": 1,
        "title": "Cancer",
        "content": "What is this?",
        "member": {
            "id": 1,
            "username": "jinsoo2005",
            "email": "jin2005@gmail.com",
            "name": "jin"
        },
        "imageUrl": null,
        "likes": 1,
        "comments": [],
        "createdAt": "2024-05-20T00:04:13.921069",
        "modifiedAt": null
    }
]
```

