### PR TITLE
feat: allow pagination when getting posts and created api endpoint to delete post and comment,

### DIFF
--- a/src/main/java/com/runningmate/backend/GlobalExceptionHandler.java
+++ b/src/main/java/com/runningmate/backend/GlobalExceptionHandler.java
@@ -40,6 +40,11 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorMessageResponseDTO(e.getMessage()));
     }
 
+    @ExceptionHandler(NoPermissionException.class)
+    public ResponseEntity<ErrorMessageResponseDTO> handleNoPermissionException(NoPermissionException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorMessageResponseDTO(e.getMessage()));
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException e) {
         Map<String, String> errors = new HashMap<>();

--- a/src/main/java/com/runningmate/backend/exception/NoPermissionException.java
+++ b/src/main/java/com/runningmate/backend/exception/NoPermissionException.java
@@ -1,0 +1,7 @@
+package com.runningmate.backend.exception;
+
+public class NoPermissionException extends RuntimeException{
+    public NoPermissionException() {
+        super("User does not have permission to perform this command");
+    }
+}

--- a/src/main/java/com/runningmate/backend/posts/controller/CommentController.java
+++ b/src/main/java/com/runningmate/backend/posts/controller/CommentController.java
@@ -1,11 +1,23 @@
 package com.runningmate.backend.posts.controller;
 
+import com.runningmate.backend.posts.service.CommentService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/comments")
 public class CommentController {
+    private final CommentService commentService;
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/{commentId}")
+    public void deleteComment(@PathVariable(name = "commentId") Long commentId,
+                           @AuthenticationPrincipal UserDetails userDetails) {
+        String username = userDetails.getUsername();
+        commentService.deleteComment(commentId, username);
+    }
 }

--- a/src/main/java/com/runningmate/backend/posts/controller/PostController.java
+++ b/src/main/java/com/runningmate/backend/posts/controller/PostController.java
@@ -51,6 +51,12 @@ public class PostController {
         return postService.getRecentPostsOfFollowedMembers(user, page, size);
     }
 
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/{postId}")
+    public PostResponseDto getPost(@PathVariable(name = "postId") Long postId) {
+        return postService.getOnePost(postId);
+    }
+
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{postId}/like")
     public void toggleLike(@PathVariable(name = "postId") Long postId, Authentication authentication) {

--- a/src/main/java/com/runningmate/backend/posts/controller/PostController.java
+++ b/src/main/java/com/runningmate/backend/posts/controller/PostController.java
@@ -51,7 +51,7 @@ public class PostController {
         return postService.getRecentPostsOfFollowedMembers(user, page, size);
     }
 
-    @ResponseStatus(HttpStatus.OK)
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{postId}/like")
     public void toggleLike(@PathVariable(name = "postId") Long postId, Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();

--- a/src/main/java/com/runningmate/backend/posts/controller/PostController.java
+++ b/src/main/java/com/runningmate/backend/posts/controller/PostController.java
@@ -57,6 +57,14 @@ public class PostController {
         return postService.getOnePost(postId);
     }
 
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/{postId}")
+    public void deletePost(@PathVariable(name = "postId") Long postId,
+                           @AuthenticationPrincipal UserDetails userDetails) {
+        String username = userDetails.getUsername();
+        postService.deletePost(postId, username);
+    }
+
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{postId}/like")
     public void toggleLike(@PathVariable(name = "postId") Long postId, Authentication authentication) {

--- a/src/main/java/com/runningmate/backend/posts/service/CommentService.java
+++ b/src/main/java/com/runningmate/backend/posts/service/CommentService.java
@@ -1,5 +1,7 @@
 package com.runningmate.backend.posts.service;
 
+import com.runningmate.backend.exception.NoPermissionException;
+import com.runningmate.backend.exception.ResourceNotFoundException;
 import com.runningmate.backend.member.Member;
 import com.runningmate.backend.member.service.MemberService;
 import com.runningmate.backend.posts.Comment;
@@ -26,5 +28,27 @@ public class CommentService {
         Comment comment = dto.toEntity(member, post);
         commentRepository.save(comment);
         return new CommentResponseDto(comment);
+    }
+
+    public void deleteComment(Long commentId, String username) {
+        Comment comment = getCommentById(commentId);
+
+        if (!hasPermission(comment, username)) {
+            throw new NoPermissionException();
+        }
+
+        commentRepository.delete(comment);
+    }
+
+    public Comment getCommentById(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new ResourceNotFoundException("Comment not found with comment id " + commentId));
+    }
+
+    private boolean hasPermission(Comment comment, String username) {
+        if (comment.getMember().getUsername().equals(username)) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/com/runningmate/backend/posts/service/PostService.java
+++ b/src/main/java/com/runningmate/backend/posts/service/PostService.java
@@ -1,5 +1,6 @@
 package com.runningmate.backend.posts.service;
 
+import com.runningmate.backend.exception.NoPermissionException;
 import com.runningmate.backend.exception.ResourceNotFoundException;
 import com.runningmate.backend.member.Follow;
 import com.runningmate.backend.member.Member;
@@ -63,6 +64,15 @@ public class PostService {
         return PostResponseDto.fromEntity(post, likes);
     }
 
+    public boolean deletePost(Long postId, String username) {
+        Post post = getPostById(postId);
+        if(!hasPermission(post, username)) {
+            throw new NoPermissionException();
+        }
+        postRepository.delete(post);
+        return true;
+    }
+
     public Post getPostById(Long postId) {
         return postRepository.findById(postId).orElseThrow(() -> new ResourceNotFoundException("Post not found with id " + postId));
     }
@@ -83,5 +93,12 @@ public class PostService {
 
     public List<Post> getPostsByCreatedAt(LocalDate date) {
         return postRepository.findAllByCreatedAt(date);
+    }
+
+    private boolean hasPermission(Post post, String username) {
+        if(!post.getMember().getUsername().equals(username)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/com/runningmate/backend/posts/service/PostService.java
+++ b/src/main/java/com/runningmate/backend/posts/service/PostService.java
@@ -42,13 +42,16 @@ public class PostService {
         return postRepository.save(post);
     }
 
-    public List<PostResponseDto> getRecentPostsOfFollowedMembers(Member user) {
+    public List<PostResponseDto> getRecentPostsOfFollowedMembers(Member user, int page, int size) {
         List<Follow> follows = followRepository.findByFollower(user);
         List<Member> followedMembers = follows.stream()
                 .map(Follow::getFollowing)
                 .collect(Collectors.toList());
 
-        Pageable pageable = PageRequest.of(0, 30);
+        if (size > 30) {
+            size = 30;
+        }
+        Pageable pageable = PageRequest.of(page, size);
         List<Post> posts = postRepository.findByMemberInOrderByCreatedAtDesc(followedMembers, pageable);
 
         return posts.stream().map((Post post) -> PostResponseDto.fromEntity(post, postLikeService.getLikeCountByPostId(post.getId()))).collect(Collectors.toList());

--- a/src/main/java/com/runningmate/backend/posts/service/PostService.java
+++ b/src/main/java/com/runningmate/backend/posts/service/PostService.java
@@ -57,8 +57,14 @@ public class PostService {
         return posts.stream().map((Post post) -> PostResponseDto.fromEntity(post, postLikeService.getLikeCountByPostId(post.getId()))).collect(Collectors.toList());
     }
 
-    public Post getPostById(Long id) {
-        return postRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("Post not found with id " + id));
+    public PostResponseDto getOnePost(Long postId) {
+        Post post = getPostById(postId);
+        long likes = postLikeService.getLikeCountByPostId(postId);
+        return PostResponseDto.fromEntity(post, likes);
+    }
+
+    public Post getPostById(Long postId) {
+        return postRepository.findById(postId).orElseThrow(() -> new ResourceNotFoundException("Post not found with id " + postId));
     }
 
     public boolean toggleLike(Long postId, String username) {


### PR DESCRIPTION
# Describe your changes
- allows users to send page and size in query parameter when sending Get request to /posts
- example request
  - `GET http://serverhost/posts?page=4&size=10`
  - Limited size to max 30. Bigger than that will be processed with size 30.
  - if request param are not given then the default page is 0 and size is 30
- `DELETE http://serverhost/posts/{postId}`
- `DELETE http://serverhost/comments/{commentId}`
- both endpoints check whether the logged in user is the one that created the comment/post. If not, throws 401.
- throws 400 if post or comment does not exist

