### PR TITLE
feat: API request and response changes for course and post

### DIFF
--- a/src/main/java/com/runningmate/backend/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/runningmate/backend/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package com.runningmate.backend.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().write("{\"error\":\"Authentication required for this entry point\"}");
+        response.setContentType("application/json");
+    }
+}

--- a/src/main/java/com/runningmate/backend/config/SecurityConfiguration.java
+++ b/src/main/java/com/runningmate/backend/config/SecurityConfiguration.java
@@ -32,6 +32,7 @@ public class SecurityConfiguration {
     private final ObjectMapper objectMapper;
     private final LoginService loginService;
     private final MemberRepository memberRepository;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     private static final String[] WHITELIST_ALL = {
             "/login",
@@ -58,7 +59,10 @@ public class SecurityConfiguration {
                         authorizeRequest
                                 .requestMatchers(WHITELIST_ALL).permitAll()
                                 .requestMatchers(HttpMethod.GET, WHITELIST_GET).permitAll()
-                                .anyRequest().authenticated()));
+                                .anyRequest().authenticated()))
+                .exceptionHandling(exceptionHandling ->
+                exceptionHandling.authenticationEntryPoint(customAuthenticationEntryPoint));;
+
         http.addFilterAfter(jsonUsernamePasswordAuthenticationFilter(), LogoutFilter.class);
         http.addFilterBefore(jwtAuthenticationFilter(), JsonUsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/runningmate/backend/config/SecurityConfiguration.java
+++ b/src/main/java/com/runningmate/backend/config/SecurityConfiguration.java
@@ -10,6 +10,7 @@ import com.runningmate.backend.member.service.LoginService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -32,6 +33,16 @@ public class SecurityConfiguration {
     private final LoginService loginService;
     private final MemberRepository memberRepository;
 
+    private static final String[] WHITELIST_ALL = {
+            "/login",
+            "/signup",
+            "/auth/**"
+    };
+
+    private static final String[] WHITELIST_GET = {
+            "/posts/*"
+    };
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.formLogin((formLogin) ->
@@ -45,7 +56,8 @@ public class SecurityConfiguration {
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(((authorizeRequest) ->
                         authorizeRequest
-                                .requestMatchers("/login", "/signup", "/auth/**").permitAll()
+                                .requestMatchers(WHITELIST_ALL).permitAll()
+                                .requestMatchers(HttpMethod.GET, WHITELIST_GET).permitAll()
                                 .anyRequest().authenticated()));
         http.addFilterAfter(jsonUsernamePasswordAuthenticationFilter(), LogoutFilter.class);
         http.addFilterBefore(jwtAuthenticationFilter(), JsonUsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/runningmate/backend/posts/controller/PostController.java
+++ b/src/main/java/com/runningmate/backend/posts/controller/PostController.java
@@ -61,8 +61,15 @@ public class PostController {
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{postId}")
-    public PostResponseDto getPost(@PathVariable(name = "postId") Long postId) {
-        return postService.getOnePost(postId);
+    public PostResponseDto getPost(@PathVariable(name = "postId") Long postId,
+                                   @AuthenticationPrincipal UserDetails userDetails) {
+        if (userDetails == null) {
+            return postService.getOnePost(postId);
+        } else {
+            String username = userDetails.getUsername();
+            Member user = memberService.getMemberByUsername(username);
+            return postService.getOnePost(postId, user);
+        }
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/runningmate/backend/posts/dto/PostResponseDto.java
+++ b/src/main/java/com/runningmate/backend/posts/dto/PostResponseDto.java
@@ -20,11 +20,12 @@ public class PostResponseDto {
     private MemberDto member;
     private List<String> imageUrls;
     private long likes;
+    private boolean liked;
     private List<CommentResponseDto> comments;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
-    public static PostResponseDto fromEntity(Post post, long likes) {
+    public static PostResponseDto fromEntity(Post post, long likes, boolean liked) {
         MemberDto memberDto = MemberDto.fromEntity(post.getMember());
 
         return PostResponseDto.builder()
@@ -32,6 +33,7 @@ public class PostResponseDto {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .likes(likes)
+                .liked(liked)
                 .comments(post.getComments().stream().map(CommentResponseDto::new).collect(Collectors.toList()))
                 .createdAt(post.getCreatedAt())
                 .modifiedAt(post.getModifiedAt())

--- a/src/main/java/com/runningmate/backend/posts/service/PostService.java
+++ b/src/main/java/com/runningmate/backend/posts/service/PostService.java
@@ -34,7 +34,7 @@ public class PostService {
         Member member = memberService.getMemberByUsername(username);
         Post post = postRequest.toEntity(member, imageUrls);
         Post savedPost = postRepository.save(post);
-        return PostResponseDto.fromEntity(savedPost, 0);
+        return PostResponseDto.fromEntity(savedPost, 0, false);
     }
 
     public Post updatePost(Long id, Post updatePostDTO) {//TODO: change to PostDTO
@@ -59,13 +59,23 @@ public class PostService {
             posts = postRepository.findByMemberInOrderByCreatedAtDesc(followedMembers, pageable);
         }
 
-        return posts.stream().map((Post post) -> PostResponseDto.fromEntity(post, postLikeService.getLikeCountByPostId(post.getId()))).collect(Collectors.toList());
+        return posts.stream().map((Post post) -> PostResponseDto
+                .fromEntity(post
+                        , postLikeService.getLikeCountByPostId(post.getId())
+                        , postLikeService.hasMemberLikedPost(post.getId(), user.getId())))
+                .collect(Collectors.toList());
     }
 
     public PostResponseDto getOnePost(Long postId) {
         Post post = getPostById(postId);
         long likes = postLikeService.getLikeCountByPostId(postId);
-        return PostResponseDto.fromEntity(post, likes);
+        return PostResponseDto.fromEntity(post, likes, false);
+    }
+
+    public PostResponseDto getOnePost(Long postId, Member user) {
+        Post post = getPostById(postId);
+        long likes = postLikeService.getLikeCountByPostId(postId);
+        return PostResponseDto.fromEntity(post, likes, postLikeService.hasMemberLikedPost(postId, user.getId()));
     }
 
     public boolean deletePost(Long postId, String username) {

--- a/src/main/java/com/runningmate/backend/route/Route.java
+++ b/src/main/java/com/runningmate/backend/route/Route.java
@@ -32,9 +32,6 @@ public class Route extends BaseTimeEntity {
     private Integer difficulty;
 
     @Column(nullable = false)
-    private String time;
-
-    @Column(nullable = false)
     private Double distance;
 
     @Column(columnDefinition = "geography(LineString, 4326)")

--- a/src/main/java/com/runningmate/backend/route/dto/RouteRequestDto.java
+++ b/src/main/java/com/runningmate/backend/route/dto/RouteRequestDto.java
@@ -22,7 +22,7 @@ public class RouteRequestDto {
     private List<CoordinateDto> route;
 
     @NotNull(message = "Distance Field has to be set.")
-    @Digits(integer = 3, fraction = 2, message = "Up to 3 digits and 2 decimal places. Example: 128.11")
+    @Max(value = 300, message = "Distance can't be larger than 300km")
     private Double distance;
 
     @NotBlank(message = "Title must be given.")

--- a/src/main/java/com/runningmate/backend/route/dto/RouteRequestDto.java
+++ b/src/main/java/com/runningmate/backend/route/dto/RouteRequestDto.java
@@ -28,9 +28,10 @@ public class RouteRequestDto {
     @NotBlank(message = "Title must be given.")
     private String title;
 
-    @NotBlank(message = "Time must be given")
-    @Pattern(regexp = "^(2[0-4]|[01]?[0-9]):[0-5][0-9]$|^(2[0-4]|[01]?[0-9])$", message = "Invalid time format. HH:MM, H:MM, M, MM")
-    private String time;
+    //Remove time for now. Might add again later
+//    @NotBlank(message = "Time must be given")
+//    @Pattern(regexp = "^(2[0-4]|[01]?[0-9]):[0-5][0-9]$|^(2[0-4]|[01]?[0-9])$", message = "Invalid time format. HH:MM, H:MM, M, MM")
+//    private String time;
 
     @NotNull(message = "Choose difficulty between 0(EASY), 1(MEDIUM), 2(HARD)")
     @Min(value = 0, message = "Difficulty must be between 0 and 2")
@@ -42,7 +43,7 @@ public class RouteRequestDto {
                 .member(member)
                 .path(path)
                 .difficulty(difficulty)
-                .time(time)
+//                .time(time)
                 .title(title)
                 .distance(distance)
                 .build();

--- a/src/main/java/com/runningmate/backend/route/dto/RouteResponseDto.java
+++ b/src/main/java/com/runningmate/backend/route/dto/RouteResponseDto.java
@@ -18,7 +18,7 @@ public class RouteResponseDto {
     private String title;
     private Double distance;
     private Integer difficulty;
-    private String time;
+//    private String time;
     private MemberDto member;
     @JsonProperty("course")
     private List<CoordinateDto> route;
@@ -28,7 +28,7 @@ public class RouteResponseDto {
         this.member = MemberDto.fromEntity(route.getMember());
         this.distance = route.getDistance();
         this.difficulty = route.getDifficulty();
-        this.time = route.getTime();
+//        this.time = route.getTime();
         this.title = route.getTitle();
         this.route = routes;
     }


### PR DESCRIPTION
# Describe your changes
- removed time field for request to create course
- get any number of decimal points and save all (front end will round up if necessary)
- changed JWTAuthenticationFilter to accept request with no authentication token
  - _**PROBLEM**_ : When request is made with no authentication to an endpoint that requires authentication. Server responds with 403 instead of 401. 
    - Possible Solution1: Frontend requests with mock token if user does not have access token
    - Possible Solution2: Change Spring Security Configuration to return 401 instead of 403 for not permitted. This might be better since im not using spring security's ROLE

# Photo

With No Auth, client can get the post info but liked will be False
<img width="914" alt="image" src="https://github.com/SSOCK/Back/assets/33882299/bc7b89b7-6c82-4eab-b481-116a7dd397ee">

With Auth, if user liked the post the post info will be given with liked as True

<img width="899" alt="image" src="https://github.com/SSOCK/Back/assets/33882299/159260ef-1816-471e-b293-7c9af8fa5813">

