### PR TITLE
feat: added profile picture feature for members

### DIFF
--- a/src/main/java/com/runningmate/backend/member/Member.java
+++ b/src/main/java/com/runningmate/backend/member/Member.java
@@ -14,7 +14,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class Member extends BaseTimeEntity {
-    //https://cobbybb.tistory.com/14
+    public static final String DEFAULT_PROFILE_PIC = "https://storage.googleapis.com/runningmate-bucket/Screenshot%202024-06-20%20at%203.46.14%E2%80%AFPM.png";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -53,7 +53,7 @@ public class Member extends BaseTimeEntity {
 
     @Column
     @Builder.Default
-    private String profilePicture = "https://storage.googleapis.com/runningmate-bucket/Screenshot%202024-06-20%20at%203.46.14%E2%80%AFPM.png";
+    private String profilePicture = DEFAULT_PROFILE_PIC;
 
     public void updateRefreshToken(String token) {
         this.refreshtoken = token;

--- a/src/main/java/com/runningmate/backend/member/Member.java
+++ b/src/main/java/com/runningmate/backend/member/Member.java
@@ -51,11 +51,19 @@ public class Member extends BaseTimeEntity {
     @Builder.Default
     private List<MemberRoute> memberRoutes = new ArrayList<>();
 
+    @Column
+    @Builder.Default
+    private String profilePicture = "https://storage.googleapis.com/runningmate-bucket/Screenshot%202024-06-20%20at%203.46.14%E2%80%AFPM.png";
+
     public void updateRefreshToken(String token) {
         this.refreshtoken = token;
     }
 
     public void removeRefreshToken() {
         this.refreshtoken = null;
+    }
+
+    public void updateProfilePicture(String url) {
+        this.profilePicture = url;
     }
 }

--- a/src/main/java/com/runningmate/backend/member/controller/MemberController.java
+++ b/src/main/java/com/runningmate/backend/member/controller/MemberController.java
@@ -1,19 +1,25 @@
 package com.runningmate.backend.member.controller;
 
 import com.runningmate.backend.member.Member;
+import com.runningmate.backend.member.dto.MemberDto;
 import com.runningmate.backend.member.dto.MemberListResponseDto;
 import com.runningmate.backend.member.service.MemberService;
+import com.runningmate.backend.posts.service.GcsFileStorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/member")
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;
+    private final GcsFileStorageService gcsFileStorageService;
 
     @ResponseStatus(value = HttpStatus.CREATED)
     @PostMapping("/{memberId}/follow")
@@ -43,5 +49,14 @@ public class MemberController {
     @GetMapping("/{memberId}/followings")
     public MemberListResponseDto getFollowingList(@PathVariable(name = "memberId") Long memberId) {
         return memberService.getFollowingList(memberId);
+    }
+
+    @ResponseStatus(value = HttpStatus.CREATED)
+    @PostMapping("/update/profile-picture")
+    public MemberDto updateProfilePicture(@RequestParam(name = "image") MultipartFile image,
+                                          @AuthenticationPrincipal UserDetails userDetails) throws IOException {
+        Member member = memberService.getMemberByUsername(userDetails.getUsername());
+        String imageUrl = gcsFileStorageService.storeFile(image);
+        return MemberDto.fromEntity(memberService.updateMemberProfilePicture(member, imageUrl));
     }
 }

--- a/src/main/java/com/runningmate/backend/member/dto/MemberDto.java
+++ b/src/main/java/com/runningmate/backend/member/dto/MemberDto.java
@@ -12,6 +12,7 @@ public class MemberDto {
     private String username;
     private String email;
     private String name;
+    private String profilePicture;
 
     public static MemberDto fromEntity(Member member) {
         return MemberDto.builder()
@@ -19,6 +20,7 @@ public class MemberDto {
                 .username(member.getUsername())
                 .email(member.getEmail())
                 .name(member.getName())
+                .profilePicture(member.getProfilePicture())
                 .build();
     }
 }

--- a/src/main/java/com/runningmate/backend/member/service/MemberService.java
+++ b/src/main/java/com/runningmate/backend/member/service/MemberService.java
@@ -14,6 +14,7 @@ import com.runningmate.backend.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -72,6 +73,11 @@ public class MemberService {
         Member member = getMemberById(memberId);
         List<Follow> follows = followRepository.findByFollower(member);
         return createMemberListResponseDto("followings", follows);
+    }
+
+    public Member updateMemberProfilePicture(Member member, String url) {
+        member.updateProfilePicture(url != null ? url : Member.DEFAULT_PROFILE_PIC);
+        return memberRepository.save(member);
     }
 
     private MemberListResponseDto createMemberListResponseDto(String type, List<Follow> follows) {

--- a/src/main/java/com/runningmate/backend/member/service/MemberService.java
+++ b/src/main/java/com/runningmate/backend/member/service/MemberService.java
@@ -70,7 +70,7 @@ public class MemberService {
 
     public MemberListResponseDto getFollowingList(Long memberId) {
         Member member = getMemberById(memberId);
-        List<Follow> follows = followRepository.findByFollowing(member);
+        List<Follow> follows = followRepository.findByFollower(member);
         return createMemberListResponseDto("followings", follows);
     }
 


### PR DESCRIPTION
# Describe your changes
- added column for profile picture for member entity
- returns link as String value to `profilePicture` key
- created api for updating profile picture for a user
  - puts default image if key `image` is given with no value
  - puts string url for image after uploading it to google cloud storage if image is given

# Response
```json
{
    "type": "followings",
    "members": [
        {
            "id": 2,
            "username": "jinsoo2006",
            "email": "jin2006@gmail.com",
            "name": "jin",
            "profilePicture": "https://storage.googleapis.com/runningmate-bucket/Screenshotasdwdasd.png"
        },
        {
            "id": 2,
            "username": "jinsoo2006",
            "email": "jin2006@gmail.com",
            "name": "jin",
            "profilePicture": "https://storage.googleapis.com/runningmate-bucket/Screenshot%20sdwoidaodn2.png"
        }
    ]
}
```

## update profile picture with `image` key with no value (sets to default)

<img width="906" alt="image" src="https://github.com/SSOCK/Back/assets/33882299/0326a3fb-ffa3-43a3-be4f-ee669f341ed0">


## update profile picture with image

<img width="890" alt="image" src="https://github.com/SSOCK/Back/assets/33882299/41d8bec5-59e9-4f29-9dcb-4e01d0600f40">


